### PR TITLE
Fix loss of first waypoint in upsample trajectory

### DIFF
--- a/tesseract_command_language/include/tesseract_command_language/joint_waypoint.h
+++ b/tesseract_command_language/include/tesseract_command_language/joint_waypoint.h
@@ -29,7 +29,6 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <Eigen/Core>
-#include <memory>
 #include <vector>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 

--- a/tesseract_command_language/include/tesseract_command_language/move_instruction.h
+++ b/tesseract_command_language/include/tesseract_command_language/move_instruction.h
@@ -28,7 +28,6 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <vector>
 #include <Eigen/Geometry>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 

--- a/tesseract_command_language/include/tesseract_command_language/poly/waypoint_poly.h
+++ b/tesseract_command_language/include/tesseract_command_language/poly/waypoint_poly.h
@@ -28,9 +28,7 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <memory>
 #include <string>
-#include <typeindex>
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/export.hpp>
 #include <boost/concept_check.hpp>

--- a/tesseract_command_language/include/tesseract_command_language/profile_dictionary.h
+++ b/tesseract_command_language/include/tesseract_command_language/profile_dictionary.h
@@ -29,7 +29,6 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <any>
-#include <iostream>
 #include <typeindex>
 #include <unordered_map>
 #include <memory>

--- a/tesseract_command_language/include/tesseract_command_language/state_waypoint.h
+++ b/tesseract_command_language/include/tesseract_command_language/state_waypoint.h
@@ -29,7 +29,6 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <Eigen/Core>
-#include <memory>
 #include <vector>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 

--- a/tesseract_command_language/include/tesseract_command_language/test_suite/instruction_poly_unit.hpp
+++ b/tesseract_command_language/include/tesseract_command_language/test_suite/instruction_poly_unit.hpp
@@ -32,7 +32,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/archive/xml_oarchive.hpp>
 #include <boost/archive/xml_iarchive.hpp>
 #include <boost/uuid/random_generator.hpp>
-#include <fstream>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_command_language/poly/instruction_poly.h>

--- a/tesseract_command_language/include/tesseract_command_language/test_suite/waypoint_poly_unit.hpp
+++ b/tesseract_command_language/include/tesseract_command_language/test_suite/waypoint_poly_unit.hpp
@@ -31,7 +31,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <gtest/gtest.h>
 #include <boost/archive/xml_oarchive.hpp>
 #include <boost/archive/xml_iarchive.hpp>
-#include <fstream>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_command_language/poly/waypoint_poly.h>

--- a/tesseract_command_language/src/cartesian_waypoint.cpp
+++ b/tesseract_command_language/src/cartesian_waypoint.cpp
@@ -1,6 +1,7 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/nvp.hpp>
+#include <iostream>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/eigen_serialization.h>

--- a/tesseract_command_language/src/joint_waypoint.cpp
+++ b/tesseract_command_language/src/joint_waypoint.cpp
@@ -4,6 +4,7 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/array.hpp>
 #include <boost/serialization/vector.hpp>
+#include <iostream>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/eigen_serialization.h>

--- a/tesseract_command_language/src/state_waypoint.cpp
+++ b/tesseract_command_language/src/state_waypoint.cpp
@@ -26,6 +26,9 @@
 
 #include <tesseract_command_language/state_waypoint.h>
 #include <tesseract_common/utils.h>
+TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <iostream>
+TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 namespace tesseract_planning
 {

--- a/tesseract_examples/include/tesseract_examples/basic_cartesian_example.h
+++ b/tesseract_examples/include/tesseract_examples/basic_cartesian_example.h
@@ -27,9 +27,6 @@
 #define TESSERACT_EXAMPLES_BASIC_CARTESIAN_EXAMPLE_H
 
 #include <tesseract_common/macros.h>
-TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <string>
-TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_examples/example.h>
 

--- a/tesseract_examples/include/tesseract_examples/example.h
+++ b/tesseract_examples/include/tesseract_examples/example.h
@@ -27,9 +27,6 @@
 #define TESSERACT_ROS_EXAMPLES_EXAMPLES_H
 
 #include <tesseract_common/macros.h>
-TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <memory>
-TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_environment/environment.h>
 #include <tesseract_visualization/visualization.h>

--- a/tesseract_examples/include/tesseract_examples/freespace_ompl_example.h
+++ b/tesseract_examples/include/tesseract_examples/freespace_ompl_example.h
@@ -27,9 +27,6 @@
 #define TESSERACT_EXAMPLES_FREESPACE_OMPL_EXAMPLE_H
 
 #include <tesseract_common/macros.h>
-TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <string>
-TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_examples/example.h>
 

--- a/tesseract_examples/include/tesseract_examples/glass_upright_example.h
+++ b/tesseract_examples/include/tesseract_examples/glass_upright_example.h
@@ -27,9 +27,6 @@
 #define TESSERACT_EXAMPLES_GLASS_UPRIGHT_EXAMPLE_H
 
 #include <tesseract_common/macros.h>
-TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <string>
-TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_examples/example.h>
 

--- a/tesseract_examples/include/tesseract_examples/glass_upright_ompl_example.h
+++ b/tesseract_examples/include/tesseract_examples/glass_upright_ompl_example.h
@@ -29,7 +29,6 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <trajopt/problem_description.hpp>
-#include <string>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_examples/example.h>

--- a/tesseract_examples/include/tesseract_examples/online_planning_example.h
+++ b/tesseract_examples/include/tesseract_examples/online_planning_example.h
@@ -35,7 +35,7 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <string>
-#include <Eigen/Eigen>
+#include <Eigen/Core>
 #include <trajopt_sqp/qp_problem.h>
 
 #include <trajopt_ifopt/constraints/cartesian_position_constraint.h>

--- a/tesseract_examples/include/tesseract_examples/pick_and_place_example.h
+++ b/tesseract_examples/include/tesseract_examples/pick_and_place_example.h
@@ -28,7 +28,6 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <string>
 #include <array>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 

--- a/tesseract_examples/src/online_planning_example.cpp
+++ b/tesseract_examples/src/online_planning_example.cpp
@@ -31,7 +31,7 @@
  */
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <Eigen/Dense>
+#include <Eigen/Geometry>
 #include <console_bridge/console.h>
 
 #include <trajopt_sqp/ifopt_qp_problem.h>

--- a/tesseract_motion_planners/core/include/tesseract_motion_planners/core/planner.h
+++ b/tesseract_motion_planners/core/include/tesseract_motion_planners/core/planner.h
@@ -26,11 +26,6 @@
 #ifndef TESSERACT_MOTION_PLANNERS_PLANNER_H
 #define TESSERACT_MOTION_PLANNERS_PLANNER_H
 
-#include <tesseract_common/macros.h>
-TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <unordered_map>
-TESSERACT_COMMON_IGNORE_WARNINGS_POP
-
 #include <tesseract_motion_planners/core/types.h>
 
 namespace tesseract_planning

--- a/tesseract_motion_planners/core/include/tesseract_motion_planners/core/utils.h
+++ b/tesseract_motion_planners/core/include/tesseract_motion_planners/core/utils.h
@@ -29,7 +29,6 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <Eigen/Geometry>
-#include <memory>
 #include <console_bridge/console.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 

--- a/tesseract_motion_planners/core/src/utils.cpp
+++ b/tesseract_motion_planners/core/src/utils.cpp
@@ -26,8 +26,8 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <Eigen/Geometry>
+#include <iostream>
 #include <memory>
-#include <typeindex>
 #include <console_bridge/console.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 

--- a/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/descartes_collision_edge_evaluator.h
+++ b/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/descartes_collision_edge_evaluator.h
@@ -28,7 +28,6 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <memory>
 #include <vector>
 #include <descartes_light/core/edge_evaluator.h>
 #include <tesseract_environment/environment.h>

--- a/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/descartes_robot_sampler.h
+++ b/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/descartes_robot_sampler.h
@@ -28,7 +28,7 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <descartes_light/core/waypoint_sampler.h>
-#include <Eigen/Dense>
+#include <Eigen/Geometry>
 #include <vector>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 

--- a/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/impl/descartes_collision_edge_evaluator.hpp
+++ b/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/impl/descartes_collision_edge_evaluator.hpp
@@ -28,7 +28,6 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <numeric>
 #include <thread>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 

--- a/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/profile/descartes_profile.h
+++ b/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/profile/descartes_profile.h
@@ -28,7 +28,6 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <vector>
 #include <memory>
 #include <Eigen/Geometry>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP

--- a/tesseract_motion_planners/descartes/src/serialize.cpp
+++ b/tesseract_motion_planners/descartes/src/serialize.cpp
@@ -27,7 +27,6 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <string>
-#include <fstream>
 #include <console_bridge/console.h>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>

--- a/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_pipeline.h
+++ b/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_pipeline.h
@@ -29,7 +29,6 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <string>
-#include <vector>
 #include <memory>
 #include <optional>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP

--- a/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_task.h
+++ b/tesseract_task_composer/core/include/tesseract_task_composer/core/task_composer_task.h
@@ -29,7 +29,6 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <string>
-#include <vector>
 #include <memory>
 #include <optional>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP

--- a/tesseract_task_composer/core/include/tesseract_task_composer/core/test_suite/task_composer_serialization_utils.hpp
+++ b/tesseract_task_composer/core/include/tesseract_task_composer/core/test_suite/task_composer_serialization_utils.hpp
@@ -8,7 +8,6 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/archive/xml_iarchive.hpp>
 #include <boost/serialization/unique_ptr.hpp>
 #include <boost/serialization/shared_ptr.hpp>
-#include <fstream>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_common/serialization.h>

--- a/tesseract_task_composer/examples/task_composer_raster_example.cpp
+++ b/tesseract_task_composer/examples/task_composer_raster_example.cpp
@@ -2,6 +2,7 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <fstream>
+#include <iostream>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_task_composer/core/task_composer_graph.h>

--- a/tesseract_task_composer/examples/task_composer_trajopt_example.cpp
+++ b/tesseract_task_composer/examples/task_composer_trajopt_example.cpp
@@ -1,8 +1,8 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
+#include <iostream>
 #include <memory>
-#include <numeric>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_task_composer/core/task_composer_graph.h>

--- a/tesseract_task_composer/planning/include/tesseract_task_composer/planning/nodes/check_input_task.h
+++ b/tesseract_task_composer/planning/include/tesseract_task_composer/planning/nodes/check_input_task.h
@@ -29,7 +29,6 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <boost/serialization/access.hpp>
-#include <functional>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_task_composer/core/task_composer_task.h>

--- a/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/check_input_profile.h
+++ b/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/check_input_profile.h
@@ -29,7 +29,6 @@
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <console_bridge/console.h>
-#include <vector>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_task_composer/core/task_composer_context.h>

--- a/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/fix_state_bounds_profile.h
+++ b/tesseract_task_composer/planning/include/tesseract_task_composer/planning/profiles/fix_state_bounds_profile.h
@@ -28,8 +28,7 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <numeric>
-#include <unordered_map>
+#include <limits>
 #include <memory>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 

--- a/tesseract_task_composer/planning/src/nodes/upsample_trajectory_task.cpp
+++ b/tesseract_task_composer/planning/src/nodes/upsample_trajectory_task.cpp
@@ -137,6 +137,7 @@ void UpsampleTrajectoryTask::upsample(CompositeInstruction& composite,
       if (start_instruction.isNull())
       {
         start_instruction = i.as<MoveInstructionPoly>();
+        composite.push_back(i);
         continue;
       }
 

--- a/tesseract_task_composer/planning/src/nodes/upsample_trajectory_task.cpp
+++ b/tesseract_task_composer/planning/src/nodes/upsample_trajectory_task.cpp
@@ -137,7 +137,7 @@ void UpsampleTrajectoryTask::upsample(CompositeInstruction& composite,
       if (start_instruction.isNull())
       {
         start_instruction = i.as<MoveInstructionPoly>();
-        composite.push_back(i);
+        composite.push_back(i); // Prevents loss of very first waypoint when upsampling
         continue;
       }
 

--- a/tesseract_task_composer/test/tesseract_task_composer_planning_unit.cpp
+++ b/tesseract_task_composer/test/tesseract_task_composer_planning_unit.cpp
@@ -2,7 +2,6 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <gtest/gtest.h>
 #include <yaml-cpp/yaml.h>
-#include <sstream>
 #include <memory>
 #include <boost/algorithm/string.hpp>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP

--- a/tesseract_task_composer/test/tesseract_task_composer_planning_unit.cpp
+++ b/tesseract_task_composer/test/tesseract_task_composer_planning_unit.cpp
@@ -1616,7 +1616,7 @@ TEST_F(TesseractTaskComposerPlanningUnit, TaskComposerUpsampleTrajectoryTaskTest
     EXPECT_EQ(node_info->isAborted(), false);
     EXPECT_EQ(input->isAborted(), false);
     EXPECT_EQ(input->isSuccessful(), true);
-    EXPECT_EQ(input->data_storage.getData("output_data").as<CompositeInstruction>().size(), 17);
+    EXPECT_EQ(input->data_storage.getData("output_data").as<CompositeInstruction>().size(), 18);
     EXPECT_TRUE(input->task_infos.getAbortingNode().is_nil());
   }
 
@@ -1736,7 +1736,7 @@ TEST_F(TesseractTaskComposerPlanningUnit, TaskComposerIterativeSplineParameteriz
       UpsampleTrajectoryTask task("abc", "input_data", "output_data", true);
       EXPECT_EQ(task.run(*input), 1);
       data.setData("input_data", input->data_storage.getData("output_data"));
-      EXPECT_EQ(input->data_storage.getData("output_data").as<CompositeInstruction>().size(), 17);
+      EXPECT_EQ(input->data_storage.getData("output_data").as<CompositeInstruction>().size(), 18);
     }
     auto profiles = std::make_shared<ProfileDictionary>();
     auto problem = std::make_unique<PlanningTaskComposerProblem>(env_, manip_, data, profiles, "abc");
@@ -1750,7 +1750,7 @@ TEST_F(TesseractTaskComposerPlanningUnit, TaskComposerIterativeSplineParameteriz
     EXPECT_EQ(node_info->isAborted(), false);
     EXPECT_EQ(input->isAborted(), false);
     EXPECT_EQ(input->isSuccessful(), true);
-    EXPECT_EQ(input->data_storage.getData("output_data").as<CompositeInstruction>().size(), 17);
+    EXPECT_EQ(input->data_storage.getData("output_data").as<CompositeInstruction>().size(), 18);
     EXPECT_TRUE(input->task_infos.getAbortingNode().is_nil());
   }
 
@@ -1873,7 +1873,7 @@ TEST_F(TesseractTaskComposerPlanningUnit, TaskComposerTimeOptimalParameterizatio
       UpsampleTrajectoryTask task("abc", "input_data", "output_data", true);
       EXPECT_EQ(task.run(*input), 1);
       data.setData("input_data", input->data_storage.getData("output_data"));
-      EXPECT_EQ(input->data_storage.getData("output_data").as<CompositeInstruction>().size(), 17);
+      EXPECT_EQ(input->data_storage.getData("output_data").as<CompositeInstruction>().size(), 18);
     }
     auto profiles = std::make_shared<ProfileDictionary>();
     auto problem = std::make_unique<PlanningTaskComposerProblem>(env_, manip_, data, profiles, "abc");
@@ -1887,7 +1887,7 @@ TEST_F(TesseractTaskComposerPlanningUnit, TaskComposerTimeOptimalParameterizatio
     EXPECT_EQ(node_info->isAborted(), false);
     EXPECT_EQ(input->isAborted(), false);
     EXPECT_EQ(input->isSuccessful(), true);
-    EXPECT_EQ(input->data_storage.getData("output_data").as<CompositeInstruction>().size(), 17);
+    EXPECT_EQ(input->data_storage.getData("output_data").as<CompositeInstruction>().size(), 18);
     EXPECT_TRUE(input->task_infos.getAbortingNode().is_nil());
 
     // Serialization
@@ -2014,14 +2014,14 @@ TEST_F(TesseractTaskComposerPlanningUnit, TaskComposerRuckigTrajectorySmoothingT
       UpsampleTrajectoryTask task("abc", "input_data", "output_data", true);
       EXPECT_EQ(task.run(*input), 1);
       data.setData("input_data", input->data_storage.getData("output_data"));
-      EXPECT_EQ(input->data_storage.getData("output_data").as<CompositeInstruction>().size(), 17);
+      EXPECT_EQ(input->data_storage.getData("output_data").as<CompositeInstruction>().size(), 18);
 
       auto problem2 = std::make_unique<PlanningTaskComposerProblem>(env_, manip_, data, profiles, "abc");
       auto input2 = std::make_unique<TaskComposerInput>(std::move(problem2));
       TimeOptimalParameterizationTask task2("abc", "input_data", "output_data", true);
       EXPECT_EQ(task2.run(*input2), 1);
       data.setData("input_data", input2->data_storage.getData("output_data"));
-      EXPECT_EQ(input2->data_storage.getData("output_data").as<CompositeInstruction>().size(), 17);
+      EXPECT_EQ(input2->data_storage.getData("output_data").as<CompositeInstruction>().size(), 18);
     }
     auto profiles = std::make_shared<ProfileDictionary>();
     auto problem = std::make_unique<PlanningTaskComposerProblem>(env_, manip_, data, profiles, "abc");
@@ -2035,7 +2035,7 @@ TEST_F(TesseractTaskComposerPlanningUnit, TaskComposerRuckigTrajectorySmoothingT
     EXPECT_EQ(node_info->isAborted(), false);
     EXPECT_EQ(input->isAborted(), false);
     EXPECT_EQ(input->isSuccessful(), true);
-    EXPECT_EQ(input->data_storage.getData("output_data").as<CompositeInstruction>().size(), 17);
+    EXPECT_EQ(input->data_storage.getData("output_data").as<CompositeInstruction>().size(), 18);
     EXPECT_TRUE(input->task_infos.getAbortingNode().is_nil());
   }
 

--- a/tesseract_task_composer/test/tesseract_task_composer_taskflow_unit.cpp
+++ b/tesseract_task_composer/test/tesseract_task_composer_taskflow_unit.cpp
@@ -2,7 +2,6 @@
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <gtest/gtest.h>
 #include <yaml-cpp/yaml.h>
-#include <sstream>
 #include <memory>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 

--- a/tesseract_time_parameterization/core/include/tesseract_time_parameterization/core/tesseract_common_trajectory.h
+++ b/tesseract_time_parameterization/core/include/tesseract_time_parameterization/core/tesseract_common_trajectory.h
@@ -26,12 +26,7 @@
 #ifndef TESSERACT_COMMON_TRAJECTORY_H
 #define TESSERACT_COMMON_TRAJECTORY_H
 
-#include <tesseract_common/macros.h>
 #include <tesseract_common/joint_state.h>
-TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <vector>
-TESSERACT_COMMON_IGNORE_WARNINGS_POP
-
 #include <tesseract_time_parameterization/core/trajectory_container.h>
 
 namespace tesseract_planning

--- a/tesseract_time_parameterization/core/include/tesseract_time_parameterization/core/trajectory_container.h
+++ b/tesseract_time_parameterization/core/include/tesseract_time_parameterization/core/trajectory_container.h
@@ -28,7 +28,7 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <Eigen/Eigen>
+#include <Eigen/Core>
 #include <memory>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 

--- a/tesseract_time_parameterization/core/include/tesseract_time_parameterization/core/utils.h
+++ b/tesseract_time_parameterization/core/include/tesseract_time_parameterization/core/utils.h
@@ -26,7 +26,6 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <Eigen/Eigen>
 #include <console_bridge/console.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 

--- a/tesseract_time_parameterization/isp/include/tesseract_time_parameterization/isp/iterative_spline_parameterization.h
+++ b/tesseract_time_parameterization/isp/include/tesseract_time_parameterization/isp/iterative_spline_parameterization.h
@@ -40,7 +40,7 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <Eigen/Eigen>
+#include <Eigen/Core>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_time_parameterization/core/trajectory_container.h>

--- a/tesseract_time_parameterization/ruckig/include/tesseract_time_parameterization/ruckig/ruckig_trajectory_smoothing.h
+++ b/tesseract_time_parameterization/ruckig/include/tesseract_time_parameterization/ruckig/ruckig_trajectory_smoothing.h
@@ -27,7 +27,7 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <Eigen/Eigen>
+#include <Eigen/Core>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_time_parameterization/core/trajectory_container.h>

--- a/tesseract_time_parameterization/totg/include/tesseract_time_parameterization/totg/time_optimal_trajectory_generation.h
+++ b/tesseract_time_parameterization/totg/include/tesseract_time_parameterization/totg/time_optimal_trajectory_generation.h
@@ -41,7 +41,7 @@
 
 #include <tesseract_common/macros.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
-#include <Eigen/Eigen>
+#include <Eigen/Core>
 #include <list>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 


### PR DESCRIPTION
The current implementation of the upscale trajectory task fails to pass the first waypoint through to the output. This small patch should fix the problem.

### Demonstration of bug
I ran the following dummy trajectory through the `UpsampleTrajectoryTask` with `longest_valid_segment_length=0.5`:
```
Composite Instruction, Description: Tesseract Composite Instruction
{
  Move Instruction, Move Type: 1, State WP: Pos=0 0 0 0 0 0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=1 0 0 0 0 0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=2 0 0 0 0 0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=3 0 0 0 0 0
, Description: Tesseract Move Instruction
}
```

The current implementation returns the following. Note the loss of the 0 0 0 0 0 0 waypoint.
```
Composite Instruction, Description: Tesseract Composite Instruction
{
  Move Instruction, Move Type: 1, State WP: Pos=0.333333        0        0        0        0        0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=0.666667        0        0        0        0        0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=1 0 0 0 0 0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=1.33333       0       0       0       0       0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=1.66667       0       0       0       0       0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=2 0 0 0 0 0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=2.33333       0       0       0       0       0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=2.66667       0       0       0       0       0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=3 0 0 0 0 0
, Description: Tesseract Move Instruction
}
```

After applying my simple fix, the following is returned:
```
Composite Instruction, Description: Tesseract Composite Instruction
{
  Move Instruction, Move Type: 1, State WP: Pos=0 0 0 0 0 0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=0.333333        0        0        0        0        0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=0.666667        0        0        0        0        0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=1 0 0 0 0 0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=1.33333       0       0       0       0       0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=1.66667       0       0       0       0       0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=2 0 0 0 0 0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=2.33333       0       0       0       0       0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=2.66667       0       0       0       0       0
, Description: Tesseract Move Instruction
  Move Instruction, Move Type: 1, State WP: Pos=3 0 0 0 0 0
, Description: Tesseract Move Instruction
}
```

### Why the bug occurs
When looping through the waypoints of a composite instruction, pairs of waypoints are examined and interpolated between if necessary. To avoid duplication of the endpoints, the loop at line 162 ignores the first point (since it was already added as the last point of the previous interpolation). In doing so, the very first waypoint is lost when `continue` is called at line 140. The fix is simply to add the very first waypoint to the resulting composite instruction.